### PR TITLE
Support for gitlab-keys implemented

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -107,6 +107,7 @@ RUN deluser www-data \
 	&& echo "access.log = /dev/null" >> /usr/local/etc/php-fpm.d/zz-docker.conf \
 	&& chown 80:80 -R /var/lib/nginx \
 	&& chmod +x /github-keys.sh \
+	&& chmod +x /gitlab-keys.sh \
 	&& /bin/bash -c "source /init-php-conf.sh"
 
 # Expose ports

--- a/README.md
+++ b/README.md
@@ -255,6 +255,8 @@ This image supports following environment variable for automatically configuring
 |COMPOSER_INSTALL_PARAMS|composer install parameters, defaults to `--prefer-source`|
 |XDEBUG_CONFIG|Pass xdebug config string, e.g. `idekey=PHPSTORM remote_enable=1`. If no config provided the Xdebug extension will be disabled (safe for production), off by default|
 |IMPORT_GITHUB_PUB_KEYS|Will pull authorized keys allowed to connect to this image from your Github account(s).|
+|IMPORT_GITLAB_PUB_KEYS|Will pull authorized keys allowed to connect to this image from your Gitlab account(s). Note: please also setup the GITLAB_URL ENV var, else this will throw an error.|
+|GITLAB_URL| Your HTTPS Gitlab Server URL, e.g. https://gitlab.my-company.com (without the trailing /)|
 |DB_DATABASE|Database name, defaults to `db`|
 |DB_HOST|Database host, defaults to `db`|
 |DB_PASS|Database password, defaults to `pass`|

--- a/README.md
+++ b/README.md
@@ -54,7 +54,9 @@ services:
     environment:
       WWW_PORT: 8080
       ADMIN_PASSWORD: 'password'
-      IMPORT_GITHUB_PUB_KEYS: 'your-github-user-name'
+      IMPORT_GITHUB_PUB_KEYS: 'my-github-username'
+      #IMPORT_GITLAB_PUB_KEYS: 'my-gitlab-username'
+      #GITLAB_URL: 'https://gitlab.my-company.org'
       COMPOSER_INSTALL_PARAMS: '--no-dev'
   db:
     image: mariadb:latest

--- a/container-files/etc/cont-init.d/00-init-ssh
+++ b/container-files/etc/cont-init.d/00-init-ssh
@@ -35,13 +35,20 @@ chmod 600 /data/.ssh/authorized_keys
 PASS=$(pwgen -c -n -1 16)
 echo "www-data:$PASS" | chpasswd
 
-if [ -z "${IMPORT_GITHUB_PUB_KEYS+xxx}" ] || [ -z "${IMPORT_GITHUB_PUB_KEYS}" ]; then
-	echo "WARNING: env variable \$IMPORT_GITHUB_PUB_KEYS is not set. Please set it to have access to this container via SSH."
-else
+if [ -n "${IMPORT_GITHUB_PUB_KEYS}" ]; then
 	# Read passed to container ENV IMPORT_GITHUB_PUB_KEYS variable with coma-separated
 	# user list and add public key(s) for these users to authorized_keys on 'www-data' account.
 	for user in $(echo $IMPORT_GITHUB_PUB_KEYS | tr "," "\n"); do
 		echo "user: $user"
 		su www-data -c "/github-keys.sh $user"
 	done
+elif [ -n "${IMPORT_GITLAB_PUB_KEYS}" ]; then
+	# Read passed to container ENV IMPORT_GITLAB_PUB_KEYS variable with coma-separated
+	# user list and add public key(s) for these users to authorized_keys on 'www-data' account.
+	for user in $(echo $IMPORT_GITLAB_PUB_KEYS | tr "," "\n"); do
+		echo "user: $user"
+		su www-data -c "/gitlab-keys.sh ${GITLAB_URL} $user"
+	done
+else
+	echo "WARNING: env variable \$IMPORT_GITHUB_PUB_KEYS or \$IMPORT_GITLAB_PUB_KEYS is not set. Please set it to have access to this container via SSH."
 fi

--- a/container-files/gitlab-keys.sh
+++ b/container-files/gitlab-keys.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+#
+# Source: https://github.com/rtlong, https://gist.github.com/rtlong/6790049
+# Usage: /gitlab-keys.sh | bash -s <gitlab server URL> <gitlab username>
+#
+IFS="$(printf '\n\t')"
+
+GITLAB_URL="$1"
+user="$2"
+
+if [ -z "$GITLAB_URL" ];
+  echo "ERROR: \$GITLAB_URL ENV var not set. See the documentation."
+  exit 1
+fi
+
+api_response=$(curl -sSLi ${GITLAB_URL}/${user}.keys)
+keys=$(echo "$api_response" | grep -o -E 'ssh-\w+\s+[^\"]+')
+
+if [ -z "$keys" ]; then
+  echo "WARNING: ${GITLAB_URL} doesn't have any keys for '$user' user."
+else
+  echo "Importing $user's ${GITLAB_URL} pub key(s) to `whoami` account..."
+
+  [ -d ~/.ssh ] || mkdir ~/.ssh
+  [ -f ~/.ssh/authorized_keys ] || touch ~/.ssh/authorized_keys
+
+  for key in $keys; do
+    echo "Imported ${GITLAB_URL} $user key: $key"
+    grep -q "$key" ~/.ssh/authorized_keys || echo "$key ${user}@${GITLAB_URL}" >> ~/.ssh/authorized_keys
+  done
+fi

--- a/container-files/gitlab-keys.sh
+++ b/container-files/gitlab-keys.sh
@@ -9,7 +9,7 @@ IFS="$(printf '\n\t')"
 GITLAB_URL="$1"
 user="$2"
 
-if [ -z "$GITLAB_URL" ];
+if [ -z "$GITLAB_URL" ]; then
   echo "ERROR: \$GITLAB_URL ENV var not set. See the documentation."
   exit 1
 fi


### PR DESCRIPTION
additionally to the existing IMPORT_GITHUB_PUB_KEYS feature, this adds
support for self hosted gitlab servers.