### PR TITLE
Fix Xdebug configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN set -x \
 
 # Install needed tools
 RUN set -x \
-	&& apk add --no-cache make tar rsync curl jq sed bash yaml less mysql-client git nginx openssh pwgen sudo s6
+	&& apk add --no-cache make tar rsync curl jq sed bash yaml less mysql-client git nginx openssh openssh-server-pam pwgen sudo s6
 
 # Install required PHP extensions
 COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/bin/
@@ -82,6 +82,8 @@ RUN echo "xdebug.remote_enable=1" >> $PHP_INI_DIR/conf.d/docker-php-ext-xdebug.i
 	&& sed -i -r 's/.?PasswordAuthentication.+/PasswordAuthentication no/' /etc/ssh/sshd_config \
 	&& sed -i -r 's/.?ChallengeResponseAuthentication.+/ChallengeResponseAuthentication no/' /etc/ssh/sshd_config \
 	&& sed -i -r 's/.?PermitRootLogin.+/PermitRootLogin no/' /etc/ssh/sshd_config \
+	# we use PAM to make ssh daemon to load the /etc/environment (see "00-init-ssh") \
+	&& sed -i -r 's/.?UsePAM.+/UsePAM yes/' /etc/ssh/sshd_config \
 	&& sed -i '/secure_path/d' /etc/sudoers
 
 # Copy container-files

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,7 +75,6 @@ RUN curl -L https://github.com/just-containers/s6-overlay/releases/download/v${S
 RUN echo "xdebug.remote_enable=1" >> $PHP_INI_DIR/conf.d/docker-php-ext-xdebug.ini \
 	&& echo "xdebug.remote_connect_back=0" >> $PHP_INI_DIR/conf.d/docker-php-ext-xdebug.ini \
 	&& echo "xdebug.max_nesting_level=512" >> $PHP_INI_DIR/conf.d/docker-php-ext-xdebug.ini \
-	&& echo "xdebug.idekey=\"PHPSTORM\"" >> $PHP_INI_DIR/conf.d/docker-php-ext-xdebug.ini \
 	&& echo "xdebug.remote_host=debugproxy" >> $PHP_INI_DIR/conf.d/docker-php-ext-xdebug.ini \
 	&& echo "xdebug.remote_port=9010" >> $PHP_INI_DIR/conf.d/docker-php-ext-xdebug.ini \
 	&& sed -i -r 's/.?UseDNS\syes/UseDNS no/' /etc/ssh/sshd_config \

--- a/README.md
+++ b/README.md
@@ -251,7 +251,8 @@ This image supports following environment variable for automatically configuring
 |ADMIN_PASSWORD|If set, would create a Neos `admin` user with such password, optional|
 |AWS_BACKUP_ARN|Automatically import the database from `${AWS_RESOURCES_ARN}db.sql` on the first container launch. Requires `AWS_ACCESS_KEY`, `AWS_SECRET_ACCESS_KEY` and `AWS_ENDPOINT` (optional, for S3-compatible storage) to be set in order to work.|
 |COMPOSER_INSTALL_PARAMS|composer install parameters, defaults to `--prefer-source`|
-|XDEBUG_CONFIG|Pass xdebug config string, e.g. `idekey=PHPSTORM;remote_enable=1`. If no config provided the Xdebug extension will be disabled (safe for production), off by default|
+|XDEBUG_ENABLED|`0` to disable the Xdebug extension (default, if XDEBUG_CONFIG is also not defined), `1` to enabled it|
+|XDEBUG_CONFIG|Pass Xdebug config string, e.g. `idekey=PHPSTORM remote_enable=1`|
 |IMPORT_GITHUB_PUB_KEYS|Will pull authorized keys allowed to connect to this image from your Github account(s).|
 |IMPORT_GITLAB_PUB_KEYS|Will pull authorized keys allowed to connect to this image from your Gitlab account(s). Note: please also setup the GITLAB_URL ENV var, else this will throw an error.|
 |GITLAB_URL| Your HTTPS Gitlab Server URL, e.g. https://gitlab.my-company.com (without the trailing /)|
@@ -287,9 +288,10 @@ services:
   # this is your application container
   web:
     environment:
+      XDEBUG_ENABLED: "1"
       XDEBUG_CONFIG: "remote_host=debugproxy"
     links:
-    - debugproxy
+      - debugproxy
 
   # this is the additional proxy where xdebug will connect to
   debugproxy:

--- a/container-files/etc/cont-init.d/00-init-ssh
+++ b/container-files/etc/cont-init.d/00-init-ssh
@@ -52,3 +52,6 @@ elif [ -n "${IMPORT_GITLAB_PUB_KEYS}" ]; then
 else
 	echo "WARNING: env variable \$IMPORT_GITHUB_PUB_KEYS or \$IMPORT_GITLAB_PUB_KEYS is not set. Please set it to have access to this container via SSH."
 fi
+
+# Pass custom environment to SSH users, skip standard shell related vars
+env | egrep -v '^(_|CWD|MAIL|CHARSET|LANG|SSH|TERM|PATH|HOME|PWD|USER|SHELL|HOSTNAME|LOGNAME)' >> /etc/environment

--- a/container-files/init-xdebug.sh
+++ b/container-files/init-xdebug.sh
@@ -1,18 +1,27 @@
 #!/usr/bin/env bash
 set -e
 
-# XDEBUG_CONFIG is either empty (disabled) or contains a list of xdebug settings, separated by spaces.
-# These are used directly by the xdebug module (see https://xdebug.org/docs/remote) and overrides
-# the defaults. I.e.:
-#   XDEBUG_CONFIG='idekey=PHPSTORM remote_enable=1'
+# Configure Xdebug based on environment variables
+#
+# XDEBUG_ENABLED set to "1" to enable the extension
+# XDEBUG_CONFIG is passed to Xdebug to configure stuff at runtime (see https://xdebug.org/docs/remote)
 
-if [ -z "${XDEBUG_CONFIG}" ] ||  [ "${XDEBUG_CONFIG}" = "0" ] || [ "${XDEBUG_CONFIG}" = "off" ]
+if [ "${XDEBUG_ENABLED}" = "0" ] || [ "${XDEBUG_ENABLED}" = "off" ] || ( [ -z "${XDEBUG_CONFIG}" ] && [ -z "${XDEBUG_ENABLED}" ] )
 then
     sed -i -r 's/^zend_extension/;zend_extension/' "$PHP_INI_DIR/conf.d/docker-php-ext-xdebug.ini"
+    echo "PHP Xdebug extension disabled."
+
+elif [ "${XDEBUG_CONFIG}" = "0" ] || [ "${XDEBUG_CONFIG}" = "off" ]
+then
+
+    # backwards compatibility
+    sed -i -r 's/^zend_extension/;zend_extension/' "$PHP_INI_DIR/conf.d/docker-php-ext-xdebug.ini"
+    echo "PHP Xdebug extension disabled. Please use XDEBUG_ENABLED=0 in future!"
+
 else
     sed -i -r 's/^;zend_extension/zend_extension/' "$PHP_INI_DIR/conf.d/docker-php-ext-xdebug.ini"
 
-    echo "Xdebug enabled with the following config:"
+    echo "PHP Xdebug extension enabled with the following config:"
     echo "-- 8< --------------------------------------------------"
     cat "$PHP_INI_DIR/conf.d/docker-php-ext-xdebug.ini"
     echo "-- 8< --------------------------------------------------"

--- a/container-files/init-xdebug.sh
+++ b/container-files/init-xdebug.sh
@@ -1,32 +1,23 @@
 #!/usr/bin/env bash
 set -e
 
-# XDEBUG_CONFIG is either empty (disabled) or contains a list of xdebug settings, separated by semicolon:
-#
-# i.e.:
-#
-#   XDEBUG_CONFIG='idekey=PHPSTORM;remote_enable=1'
-#
-# generates these settings:
-#
-#   xdebug.idekey=PHPSTORM
-#   xdebug.remote_enable=1
+# XDEBUG_CONFIG is either empty (disabled) or contains a list of xdebug settings, separated by spaces.
+# These are used directly by the xdebug module (see https://xdebug.org/docs/remote) and overrides
+# the defaults. I.e.:
+#   XDEBUG_CONFIG='idekey=PHPSTORM remote_enable=1'
 
 if [ -z "${XDEBUG_CONFIG}" ] ||  [ "${XDEBUG_CONFIG}" = "0" ] || [ "${XDEBUG_CONFIG}" = "off" ]
 then
     sed -i -r 's/^zend_extension/;zend_extension/' "$PHP_INI_DIR/conf.d/docker-php-ext-xdebug.ini"
 else
     sed -i -r 's/^;zend_extension/zend_extension/' "$PHP_INI_DIR/conf.d/docker-php-ext-xdebug.ini"
-    if [ "${XDEBUG_CONFIG}" != "on" ] &&  [ "${XDEBUG_CONFIG}" != "1" ]; then
-      IFS=';'
-      for d in $XDEBUG_CONFIG ; do echo "xdebug.$d" >> "$PHP_INI_DIR/conf.d/docker-php-ext-xdebug.ini"; done
-      unset IFS
-    fi
 
-    echo "Xdebug enabled with the follwing config:"
+    echo "Xdebug enabled with the following config:"
     echo "-- 8< --------------------------------------------------"
     cat "$PHP_INI_DIR/conf.d/docker-php-ext-xdebug.ini"
     echo "-- 8< --------------------------------------------------"
+    echo "Overrides in XDEBUG_CONFIG: ${XDEBUG_CONFIG}"
+    echo ""
 
     # create a wrapper script "php-debug" for starting debugging from the CLI
     cat <<'EOF' > /usr/local/bin/php-debug


### PR DESCRIPTION
Xdebug was not getting correct `XDEBUG_CONFIG` settings to run via debugproxy.

Use the `XDEBUG_CONFIG` variable documented by xDebug (see https://xdebug.org/docs/remote) instead of parsing them on our own. Use it in PHP-FPM and ssh login context.