### PR TITLE
Do not set COMPOSER_HOME in the whole container but use the default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,11 +12,9 @@ ARG S6_VERSION="1.21.2.2"
 ARG COMPOSER_MAJOR_VERSION="2"
 
 ENV \
-	 COMPOSER_HOME=/composer \
-   COMPOSER_MAJOR_VERSION=${COMPOSER_MAJOR_VERSION} \
-	 PATH=/composer/vendor/bin:$PATH \
-	 COMPOSER_ALLOW_SUPERUSER=1 \
-	 COMPOSER_INSTALL_PARAMS=--prefer-source
+	COMPOSER_MAJOR_VERSION=${COMPOSER_MAJOR_VERSION} \
+	COMPOSER_ALLOW_SUPERUSER=1 \
+	COMPOSER_INSTALL_PARAMS=--prefer-source
 
 # Set default values for env vars used in init scripts, override them if needed
 ENV \


### PR DESCRIPTION
Default is `$HOME/.composer` which is okey for all use-cases. There is no need to have a global `COMPOSER_HOME` in our containers.

This fixes the user `www-data` not being able to store composer configuration or caches.

Fixes #17 