### PR TITLE
Fix using the correct images that were build in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,13 +33,13 @@ jobs:
         with:
           build-args: COMPOSER_MAJOR_VERSION=1
           load: true
-          tags: croneu/neos:${{ matrix.php-version }}-${{ matrix.target }}
+          tags: ci/croneu/neos:${{ matrix.php-version }}-${{ matrix.target }}
           target: ${{ matrix.target }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache,mode=max
       -
         name: "Save Docker Image"
-        run: docker save croneu/neos:${{ matrix.php-version }}-${{ matrix.target }} | gzip > docker-neos-${{ matrix.target }}.tar.gz
+        run: docker save ci/croneu/neos:${{ matrix.php-version }}-${{ matrix.target }} | gzip > docker-neos-${{ matrix.target }}.tar.gz
 
       - name: "Upload Docker Image as Artifact"
         uses: actions/upload-artifact@v2
@@ -93,7 +93,7 @@ jobs:
                --env="COMPOSER_INSTALL_PARAMS=--no-dev" \
                --env="VERSION=${{ matrix.neos-version }}" \
                --env="SITE_PACKAGE=Neos.Demo" \
-               croneu/neos:${{ matrix.php-version }} &
+               ci/croneu/neos:${{ matrix.php-version }}-base &
       -
         name: "Wait for Neos provisioning (max. 240 seconds)"
         run: |
@@ -174,7 +174,7 @@ jobs:
            --env="VERSION=${{ matrix.neos-version }}" \
            --env="COMPOSER_INSTALL_PARAMS=--dev" \
            --env="SITE_PACKAGE=Neos.Demo" \
-          croneu/neos:${{ matrix.php-version }} sh -c 's6-svwait -U /var/run/s6/services/selenium ; sudo -u www-data cd /data/www/Packages/Neos/Neos.Neos/Tests/Behavior /data/www/bin/behat Features/ExportImport.feature'
+          ci/croneu/neos:${{ matrix.php-version }}-behat sh -c 's6-svwait -U /var/run/s6/services/selenium ; sudo -u www-data cd /data/www/Packages/Neos/Neos.Neos/Tests/Behavior /data/www/bin/behat Features/ExportImport.feature'
       -
         name: "Cleanup: Stop running docker containers"
         run: docker stop db


### PR DESCRIPTION
Make sure to use the CI build images and not the "official" released images from docker hub by using a "ci/" prefix to the image name.

Follow-up to #22 