### PR TITLE
Add How to Test Section in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,24 @@ docker login
 make push-7.3
 ```
 
+### Test the Docker Image
+
+To test the image you can use the supplied docker-compose files in the `example` directory. For example, to run a behat enabled environment using the official Neos Distribution Package, do:
+
+```shell
+cd example
+docker-compose -f docker-compose.yml -f docker-compose.behat.yml up -d
+# ssh-keygen -R \[$(docker-machine ip $DOCKER_MACHINE_NAME)\]:1122
+ssh www-data@$(docker-machine ip $DOCKER_MACHINE_NAME) -p 1122
+```
+
+Inside the docker container, run this simple behat test:
+
+```
+cd Packages/Neos/Neos.Neos/Tests/Behavior
+behat Features/ExportImport.feature
+```
+
 ## MIT Licence
 
 See the [LICENSE](LICENSE) file.

--- a/example/docker-compose.behat.yml
+++ b/example/docker-compose.behat.yml
@@ -1,0 +1,26 @@
+---
+version: '3.7'
+
+services:
+  web:
+    # use the neos-alpine behat image instead of the default one
+    image: croneu/neos:7.3-behat
+    hostname: behat-runner
+    ports:
+      - '5900:5900'
+    environment:
+      # use a separate DB container for testing
+      DB_HOST: db-test
+      DB_DATABASE: db
+
+  db-test:
+    image: mariadb:10
+    expose:
+      - 3306
+    volumes:
+      - /var/lib/data
+    environment:
+      MYSQL_DATABASE: 'db'
+      MYSQL_USER: 'admin'
+      MYSQL_PASSWORD: 'pass'
+      MYSQL_RANDOM_ROOT_PASSWORD: 'yes'

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -1,0 +1,34 @@
+---
+version: '3.7'
+
+services:
+  web:
+    image: croneu/neos:7.3
+    ports:
+      - '8080:8080'
+      - '1122:22'
+    links:
+      - db:db
+    environment:
+      WWW_PORT: 8080
+      REPOSITORY_URL: https://github.com/neos/neos-development-distribution
+      ADMIN_PASSWORD: 'password'
+      VERSION: '4.3'
+      IMPORT_GITHUB_PUB_KEYS: ${GITHUB_USERNAME}
+  db:
+    image: mariadb:10
+    expose:
+      - 3306
+    volumes:
+      - /var/lib/data
+    environment:
+      MYSQL_DATABASE: 'db'
+      MYSQL_USER: 'admin'
+      MYSQL_PASSWORD: 'pass'
+      MYSQL_RANDOM_ROOT_PASSWORD: 'yes'
+
+volumes:
+  data:
+
+networks:
+  default:


### PR DESCRIPTION
This adds two sample docker-compose files and also a new section in the
existing README.md file how to use them to
run a simple behat test