### PR TITLE
Also include .git in Packages

### DIFF
--- a/container-files/etc/cont-init.d/10-init-neos
+++ b/container-files/etc/cont-init.d/10-init-neos
@@ -38,7 +38,7 @@ else
   # Use "-l" to avoid the "skipping non-regular file" errors
   rsync -rl \
     --exclude node_modules \
-    --exclude .git \
+    --exclude /.git \
     --exclude /Data \
     /src/ .
 fi


### PR DESCRIPTION
This allows to initialize the container without need a deploy key, also for packages which are installed with `dev-*` - as these require a cloned .git repository in place for composer install to run without requiring to fetch upstream again.