### PR TITLE
Add missing --build-arg for the php version

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -42,6 +42,7 @@ jobs:
             --cache-to "type=local,dest=/tmp/.buildx-cache" \
             --platform linux/amd64,linux/arm64 \
             --target ${{ matrix.target }} \
+            --build-arg PHP_VERSION="${{ matrix.php-version }}"
             --output "type=image,push=false" \
             --tag croneu/neos:${{ matrix.php-version }}-${{ matrix.target }} \
             --file ./Dockerfile ./
@@ -58,6 +59,7 @@ jobs:
             --cache-from "type=local,src=/tmp/.buildx-cache" \
             --platform linux/amd64,linux/arm64 \
             --target ${{ matrix.target }} \
+            --build-arg PHP_VERSION="${{ matrix.php-version }}"
             --output "type=image,push=true" \
             --tag croneu/neos:${{ matrix.php-version }}-${{ matrix.target }} \
             --file ./Dockerfile ./


### PR DESCRIPTION
This fixes an error the php 7.3 variants being built with php 7.2