### PR TITLE
Fix Neos Configuration Issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,7 @@ RUN set -x \
 
 # Install needed tools
 RUN set -x \
-	&& apk add --no-cache make tar rsync curl jq sed bash yaml less mysql-client git nginx openssh openssh-server-pam pwgen sudo s6
+	&& apk add --no-cache make tar rsync curl jq yq sed bash yaml less mysql-client git nginx openssh openssh-server-pam pwgen sudo s6
 
 # Install required PHP extensions
 COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG IMAGE_VERSION="latest"
 ARG PHP_VERSION="7.2"
-ARG ALPINE_VERSION=""
+ARG ALPINE_VERSION="3.14"
 
 # ALPINE_VERSION defines the Firefox version.
 # PHP maintaners only build PHP images for a couple variants of "selected" ALPINE_VERSION's.
@@ -19,6 +19,7 @@ ARG ALPINE_VERSION=""
 # Alpine 3.9 - firefox-esr 52.9 - works with selenium 2.53
 # Alpine 3.10 - firefox-esr 60
 # Alpine 3.12 - firefox-esr 78
+# Alpine 3.14 - firefox-esr 89
 
 # -------------------------------------------------------------------------
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG IMAGE_VERSION="latest"
 ARG PHP_VERSION="7.2"
-ARG ALPINE_VERSION="3.14"
+ARG ALPINE_VERSION="3.8"
 
 # ALPINE_VERSION defines the Firefox version.
 # PHP maintaners only build PHP images for a couple variants of "selected" ALPINE_VERSION's.
@@ -23,7 +23,7 @@ ARG ALPINE_VERSION="3.14"
 
 # -------------------------------------------------------------------------
 
-FROM php:${PHP_VERSION}-fpm-alpine${ALPINE_VERSION} as base
+FROM php:${PHP_VERSION}-fpm-alpine${ALPINE_VERSION} as builder
 
 MAINTAINER Remus Lazar <rl@cron.eu>
 
@@ -63,7 +63,7 @@ RUN set -x \
 
 # Install needed tools
 RUN set -x \
-	&& apk add --no-cache make tar rsync curl jq yq sed bash yaml less mysql-client git nginx openssh openssh-server-pam pwgen sudo s6
+	&& apk add --no-cache make tar rsync curl jq sed bash yaml less mysql-client git nginx openssh openssh-server-pam pwgen sudo s6
 
 # Install required PHP extensions
 COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/bin/
@@ -126,6 +126,15 @@ RUN deluser www-data \
 	&& chown ${UID}:${GID} -R /var/lib/nginx \
 	&& chmod +x /github-keys.sh \
 	&& chmod +x /gitlab-keys.sh
+
+FROM builder as yq-installer
+
+# Install yq (on older alpine versions)
+RUN echo "http://dl-4.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories
+RUN apk update && apk add --no-cache yq
+
+FROM builder as base
+COPY --from=yq-installer /usr/bin/yq /usr/local/bin/yq
 
 # Expose ports
 EXPOSE 80 22

--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,8 @@ PLATFORM := linux/amd64
 # See also "hooks/build" and update the builds there too
 # see https://www.docker.com/blog/multi-arch-build-and-images-the-simple-way/
 build-7.2:
-	docker buildx build --push --platform ${PLATFORM} --build-arg PHP_VERSION="7.2" --build-arg ALPINE_VERSION="3.8" --target base -t croneu/neos:7.2 .
-	docker buildx build --push --platform ${PLATFORM} --build-arg PHP_VERSION="7.2" --build-arg ALPINE_VERSION="3.8" --target behat -t croneu/neos:7.2-behat .
+	docker buildx build --push --platform ${PLATFORM} --build-arg PHP_VERSION="7.2" --target base -t croneu/neos:7.2 .
+	docker buildx build --push --platform ${PLATFORM} --build-arg PHP_VERSION="7.2" --target behat -t croneu/neos:7.2-behat .
 
 build-7.3:
 	docker buildx build --push --platform ${PLATFORM} --build-arg PHP_VERSION="7.3" --target base -t croneu/neos:7.3 .

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,8 @@ init-builder:
 
 build: build-7.2 build-7.3
 
-PLATFORM := linux/amd64,linux/arm64
+#PLATFORM := linux/amd64,linux/arm64
+PLATFORM := linux/amd64
 
 # See also "hooks/build" and update the builds there too
 # see https://www.docker.com/blog/multi-arch-build-and-images-the-simple-way/
@@ -16,5 +17,5 @@ build-7.2:
 	docker buildx build --push --platform ${PLATFORM} --build-arg PHP_VERSION="7.2" --build-arg ALPINE_VERSION="3.8" --target behat -t croneu/neos:7.2-behat .
 
 build-7.3:
-	docker buildx build --push --platform ${PLATFORM} --build-arg PHP_VERSION="7.3" --build-arg ALPINE_VERSION="3.8" --target base -t croneu/neos:7.3 .
-	docker buildx build --push --platform ${PLATFORM} --build-arg PHP_VERSION="7.3" --build-arg ALPINE_VERSION="3.8" --target behat -t croneu/neos:7.3-behat .
+	docker buildx build --push --platform ${PLATFORM} --build-arg PHP_VERSION="7.3" --target base -t croneu/neos:7.3 .
+	docker buildx build --push --platform ${PLATFORM} --build-arg PHP_VERSION="7.3" --target behat -t croneu/neos:7.3-behat .

--- a/container-files/etc/cont-init.d/10-init-neos
+++ b/container-files/etc/cont-init.d/10-init-neos
@@ -107,6 +107,12 @@ Neos:
 EOF
 else
   echo "* Skipping creating Configuration/${FLOW_SETTINGS_FILENAME} (already exists)"
+  echo "* Will update Flow.persistence.backendOptions settings in file Configuration/${FLOW_SETTINGS_FILENAME}"
+  yq e -i '.Neos.Flow.persistence.backendOptions.driver = pdo_mysql ' Configuration/${FLOW_SETTINGS_FILENAME}
+  yq e -i '.Neos.Flow.persistence.backendOptions.dbname = "%env:DB_DATABASE%" ' Configuration/${FLOW_SETTINGS_FILENAME}
+  yq e -i '.Neos.Flow.persistence.backendOptions.user = "%env:DB_USER%" ' Configuration/${FLOW_SETTINGS_FILENAME}
+  yq e -i '.Neos.Flow.persistence.backendOptions.password = "%env:DB_PASS%" ' Configuration/${FLOW_SETTINGS_FILENAME}
+  yq e -i '.Neos.Flow.persistence.backendOptions.host = "%env:DB_HOST%" ' Configuration/${FLOW_SETTINGS_FILENAME}
 fi
 
 echo "* Running doctrine:migrate"

--- a/container-files/etc/cont-init.d/10-init-neos
+++ b/container-files/etc/cont-init.d/10-init-neos
@@ -108,7 +108,7 @@ EOF
 else
   echo "* Skipping creating Configuration/${FLOW_SETTINGS_FILENAME} (already exists)"
   echo "* Will update Flow.persistence.backendOptions settings in file Configuration/${FLOW_SETTINGS_FILENAME}"
-  yq e -i '.Neos.Flow.persistence.backendOptions.driver = pdo_mysql ' Configuration/${FLOW_SETTINGS_FILENAME}
+  yq e -i '.Neos.Flow.persistence.backendOptions.driver = "pdo_mysql" ' Configuration/${FLOW_SETTINGS_FILENAME}
   yq e -i '.Neos.Flow.persistence.backendOptions.dbname = "%env:DB_DATABASE%" ' Configuration/${FLOW_SETTINGS_FILENAME}
   yq e -i '.Neos.Flow.persistence.backendOptions.user = "%env:DB_USER%" ' Configuration/${FLOW_SETTINGS_FILENAME}
   yq e -i '.Neos.Flow.persistence.backendOptions.password = "%env:DB_PASS%" ' Configuration/${FLOW_SETTINGS_FILENAME}


### PR DESCRIPTION
This fixes issues when running behat on projects which does already provide an existing `Configuration/Settings.yaml` Neos configuration file with inconsistent values, e.g. not using the same environment variable names as we're using for our logic here.

This change leverages the `yq` utility to replace the value for the database settings in place.